### PR TITLE
Add support for sshkey

### DIFF
--- a/plugin/instance/cmd/main.go
+++ b/plugin/instance/cmd/main.go
@@ -23,6 +23,7 @@ func main() {
 	region := cmd.Flags().String("region", "", "DigitalOcean region")
 	//config := cmd.Flags().String("config", "$HOME/.config/doctl/config.yaml", "configuration file where the api token are specified")
 	accessToken := cmd.Flags().String("access-token", "", "DigitalOcean token")
+	sshKey := cmd.Flags().String("sshKey", "", "Default ssh key to use for droplets (it has to exists on digitalocean)")
 
 	cmd.Run = func(c *cobra.Command, args []string) {
 		cli.SetLogLevel(*logLevel)
@@ -32,7 +33,7 @@ func main() {
 		oauthClient := oauth2.NewClient(context.TODO(), tokenSource)
 		client := godo.NewClient(oauthClient)
 
-		cli.RunPlugin(*name, instance_plugin.PluginServer(instance.NewDOInstancePlugin(client, *region)))
+		cli.RunPlugin(*name, instance_plugin.PluginServer(instance.NewDOInstancePlugin(client, *region, *sshKey)))
 	}
 
 	cmd.AddCommand(cli.VersionCommand())

--- a/plugin/instance/fake_test.go
+++ b/plugin/instance/fake_test.go
@@ -8,6 +8,21 @@ import (
 	"github.com/pkg/errors"
 )
 
+type fakeKeysService struct {
+	expectedErr string
+	listfunc    func(context.Context, *godo.ListOptions) ([]godo.Key, *godo.Response, error)
+}
+
+func (s *fakeKeysService) List(ctx context.Context, opts *godo.ListOptions) ([]godo.Key, *godo.Response, error) {
+	if s.expectedErr != "" {
+		return nil, nil, errors.New(s.expectedErr)
+	}
+	if s.listfunc != nil {
+		return s.listfunc(ctx, opts)
+	}
+	return []godo.Key{}, godoResponse(), nil
+}
+
 type fakeTagsService struct {
 	expectedErr string
 }
@@ -93,4 +108,17 @@ func tags(tags ...string) func(*godo.Droplet) {
 	return func(droplet *godo.Droplet) {
 		droplet.Tags = tags
 	}
+}
+
+func godoKey(id int, name string, ops ...func(*godo.Key)) godo.Key {
+	key := &godo.Key{
+		ID:   id,
+		Name: name,
+	}
+
+	for _, op := range ops {
+		op(key)
+	}
+
+	return *key
 }


### PR DESCRIPTION
For now, the plugin is started with a specified sshkey that should
exists on digitalocean.

Improvements will be :
- point to a local ssh key and a name and send if it doesn't exists.
- allows multiple ssh keys

Signed-off-by: Vincent Demeester <vincent@sbr.pm>