### PR TITLE
Only show infrakit provisioned instances

### DIFF
--- a/plugin/instance/plugin.go
+++ b/plugin/instance/plugin.go
@@ -315,7 +315,7 @@ func hasDifferentTag(expected, actual map[string]string) bool {
 		return true
 	}
 	for k, v := range expected {
-		if actual[k] != v {
+		if a, ok := actual[k]; ok && a != v {
 			return true
 		}
 	}


### PR DESCRIPTION
This updates the filtering to only show infrakit provisioned instances.

Example:

Before:

```
infrakit instance --name instance-digitalocean describe
ID                            	LOGICAL                       	TAGS
xxxxx                       	  -                           	gordon-bot=,kibana=,poule=
xxxxx                       	  -                           	jenkins=,leeroy=
xxxxx                        	  -                           	core=,infrakit-do-version=1,infrakit.config_sha=jr4csxn7fvgstup47sp3slt24hpezkph,infrakit.group=core
```

After:

```
infrakit instance --name instance-digitalocean describe
ID                            	LOGICAL                       	TAGS
46987886                      	  -                           	core=,infrakit-do-version=1,infrakit.config_sha=jr4csxn7fvgstup47sp3slt24hpezkph,infrakit.group=core
```