### PR TITLE
Misc fixes for the Digital Ocean instance plugin

### DIFF
--- a/plugin/instance/cmd/main.go
+++ b/plugin/instance/cmd/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"os"
+	"strings"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/digitalocean/godo"
@@ -14,6 +15,9 @@ import (
 )
 
 func main() {
+
+	var namespaceTags []string
+
 	cmd := &cobra.Command{
 		Use:   os.Args[0],
 		Short: "DigitalOcean instance plugin",
@@ -24,6 +28,11 @@ func main() {
 	//config := cmd.Flags().String("config", "$HOME/.config/doctl/config.yaml", "configuration file where the api token are specified")
 	accessToken := cmd.Flags().String("access-token", "", "DigitalOcean token")
 	sshKey := cmd.Flags().String("sshKey", "", "Default ssh key to use for droplets (it has to exists on digitalocean)")
+	cmd.Flags().StringSliceVar(
+		&namespaceTags,
+		"namespace-tags",
+		[]string{},
+		"A list of key=value resource tags to namespace all resources created")
 
 	cmd.Run = func(c *cobra.Command, args []string) {
 		cli.SetLogLevel(*logLevel)
@@ -33,7 +42,18 @@ func main() {
 		oauthClient := oauth2.NewClient(context.TODO(), tokenSource)
 		client := godo.NewClient(oauthClient)
 
-		cli.RunPlugin(*name, instance_plugin.PluginServer(instance.NewDOInstancePlugin(client, *region, *sshKey)))
+		namespace := map[string]string{}
+		for _, tagKV := range namespaceTags {
+			keyAndValue := strings.Split(tagKV, "=")
+			if len(keyAndValue) != 2 {
+				log.Error("Namespace tags must be formatted as key=value")
+				os.Exit(1)
+			}
+
+			namespace[keyAndValue[0]] = keyAndValue[1]
+		}
+
+		cli.RunPlugin(*name, instance_plugin.PluginServer(instance.NewDOInstancePlugin(client, *region, *sshKey, namespace)))
 	}
 
 	cmd.AddCommand(cli.VersionCommand())

--- a/plugin/instance/cmd/main.go
+++ b/plugin/instance/cmd/main.go
@@ -24,10 +24,10 @@ func main() {
 	}
 	name := cmd.Flags().String("name", "instance-digitalocean", "Plugin name to advertise for discovery")
 	logLevel := cmd.Flags().Int("log", cli.DefaultLogLevel, "Logging level. 0 is least verbose. Max is 5")
-	region := cmd.Flags().String("region", "", "DigitalOcean region")
+
 	//config := cmd.Flags().String("config", "$HOME/.config/doctl/config.yaml", "configuration file where the api token are specified")
 	accessToken := cmd.Flags().String("access-token", "", "DigitalOcean token")
-	sshKey := cmd.Flags().String("sshKey", "", "Default ssh key to use for droplets (it has to exists on digitalocean)")
+
 	cmd.Flags().StringSliceVar(
 		&namespaceTags,
 		"namespace-tags",
@@ -53,7 +53,7 @@ func main() {
 			namespace[keyAndValue[0]] = keyAndValue[1]
 		}
 
-		cli.RunPlugin(*name, instance_plugin.PluginServer(instance.NewDOInstancePlugin(client, *region, *sshKey, namespace)))
+		cli.RunPlugin(*name, instance_plugin.PluginServer(instance.NewDOInstancePlugin(client, namespace)))
 	}
 
 	cmd.AddCommand(cli.VersionCommand())

--- a/plugin/instance/plugin_test.go
+++ b/plugin/instance/plugin_test.go
@@ -119,14 +119,13 @@ func TestProvisionFails(t *testing.T) {
 	spec := instance.Spec{
 		Properties: types.AnyString(`{
   "NamePrefix": "foo",
+  "Region" : "asm2",
   "Size": "512mb",
-  "Image": "ubuntu-14-04-x64",
+  "Image": { "Slug" : "ubuntu-14-04-x64" },
   "Tags": ["foo"]
 }`),
 	}
-	region := "asm2"
 	plugin := &plugin{
-		region: region,
 		droplets: &fakeDropletsServices{
 			expectedErr: "something went wrong",
 		},
@@ -140,15 +139,14 @@ func TestProvisionFailsWithSshKey(t *testing.T) {
 	spec := instance.Spec{
 		Properties: types.AnyString(`{
   "NamePrefix": "foo",
+  "Region" : "asm2",
   "Size": "512mb",
-  "Image": "ubuntu-14-04-x64",
-  "Tags": ["foo"]
+  "Image": { "Slug" : "ubuntu-14-04-x64" },
+  "Tags": ["foo"],
+  "SSHKeyNames" : [ "foo" ]
 }`),
 	}
-	region := "asm2"
 	plugin := &plugin{
-		region: region,
-		sshkey: "foo",
 		droplets: &fakeDropletsServices{
 			expectedErr: "should not have error out here",
 		},
@@ -164,19 +162,18 @@ func TestProvision(t *testing.T) {
 	spec := instance.Spec{
 		Properties: types.AnyString(`{
   "NamePrefix": "foo",
+  "Region" : "asm2",
   "Size": "512mb",
-  "Image": "ubuntu-14-04-x64",
+  "Image": { "Slug" : "ubuntu-14-04-x64" },
   "Tags": ["foo"]
 }`),
 	}
-	region := "asm2"
 	versiontag := fmt.Sprintf("%s:%s", itypes.InfrakitDOVersion, itypes.InfrakitDOCurrentVersion)
 	plugin := &plugin{
-		region: region,
 		droplets: &fakeDropletsServices{
 			createfunc: func(ctx context.Context, req *godo.DropletCreateRequest) (*godo.Droplet, *godo.Response, error) {
 				assert.Contains(t, req.Name, "foo")
-				assert.Equal(t, region, req.Region)
+				assert.Equal(t, req.Region, "asm2")
 				assert.Equal(t, "512mb", req.Size)
 				assert.Equal(t, godo.DropletCreateImage{
 					Slug: "ubuntu-14-04-x64",
@@ -200,15 +197,14 @@ func TestProvisionNonExistingSshkey(t *testing.T) {
 	spec := instance.Spec{
 		Properties: types.AnyString(`{
   "NamePrefix": "foo",
+  "Region" : "asm2",
   "Size": "512mb",
-  "Image": "ubuntu-14-04-x64",
-  "Tags": ["foo"]
+  "Image": { "Slug" : "ubuntu-14-04-x64" },
+  "Tags": ["foo"],
+  "SSHKeyNames" : [ "foo" ]
 }`),
 	}
-	region := "asm2"
 	plugin := &plugin{
-		region: region,
-		sshkey: "foo",
 		droplets: &fakeDropletsServices{
 			createfunc: func(ctx context.Context, req *godo.DropletCreateRequest) (*godo.Droplet, *godo.Response, error) {
 				assert.Equal(t, 1, len(req.SSHKeys))
@@ -236,15 +232,14 @@ func TestProvisionExistingSshkey(t *testing.T) {
 	spec := instance.Spec{
 		Properties: types.AnyString(`{
   "NamePrefix": "foo",
+  "Region" : "asm2",
   "Size": "512mb",
-  "Image": "ubuntu-14-04-x64",
-  "Tags": ["foo"]
+  "Image": { "Slug" : "ubuntu-14-04-x64" },
+  "Tags": ["foo"],
+  "SSHKeyNames" : [ "foo" ]
 }`),
 	}
-	region := "asm2"
 	plugin := &plugin{
-		region: region,
-		sshkey: "foo",
 		droplets: &fakeDropletsServices{
 			createfunc: func(ctx context.Context, req *godo.DropletCreateRequest) (*godo.Droplet, *godo.Response, error) {
 				assert.Equal(t, 1, len(req.SSHKeys))
@@ -281,9 +276,7 @@ func isInSlice(s string, strings []string) assert.Comparison {
 }
 
 func TestDescribeInstancesFails(t *testing.T) {
-	region := "asm2"
 	plugin := &plugin{
-		region: region,
 		droplets: &fakeDropletsServices{
 			expectedErr: "something went wrong",
 		},
@@ -293,9 +286,7 @@ func TestDescribeInstancesFails(t *testing.T) {
 }
 
 func TestDescribeInstancesNone(t *testing.T) {
-	region := "asm2"
 	plugin := &plugin{
-		region: region,
 		droplets: &fakeDropletsServices{
 			listfunc: func(context.Context, *godo.ListOptions) ([]godo.Droplet, *godo.Response, error) {
 				return []godo.Droplet{
@@ -313,9 +304,7 @@ func TestDescribeInstancesNone(t *testing.T) {
 }
 
 func TestDescribeInstances(t *testing.T) {
-	region := "asm2"
 	plugin := &plugin{
-		region: region,
 		droplets: &fakeDropletsServices{
 			listfunc: func(context.Context, *godo.ListOptions) ([]godo.Droplet, *godo.Response, error) {
 				return []godo.Droplet{
@@ -333,9 +322,7 @@ func TestDescribeInstances(t *testing.T) {
 }
 
 func TestDescribeInstancesHandlesPages(t *testing.T) {
-	region := "asm2"
 	plugin := &plugin{
-		region: region,
 		droplets: &fakeDropletsServices{
 			listfunc: func(_ context.Context, opts *godo.ListOptions) ([]godo.Droplet, *godo.Response, error) {
 				resp := godoResponse(hasNextPage)

--- a/plugin/instance/plugin_test.go
+++ b/plugin/instance/plugin_test.go
@@ -3,6 +3,7 @@ package instance
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"testing"
 
 	"github.com/digitalocean/godo"
@@ -79,8 +80,9 @@ func TestDestroyFails(t *testing.T) {
 	}
 	id := instance.ID("foo")
 	err := plugin.Destroy(id)
-
-	require.EqualError(t, err, "strconv.ParseInt: parsing \"foo\": invalid syntax")
+	require.Error(t, err)
+	_, is := err.(*strconv.NumError)
+	require.True(t, is)
 
 	id = instance.ID("12345")
 	err = plugin.Destroy(id)

--- a/plugin/instance/plugin_test.go
+++ b/plugin/instance/plugin_test.go
@@ -40,6 +40,23 @@ func TestLabelFails(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestBuildCloudInit(t *testing.T) {
+	cloudInit, err := buildCloudInit(
+		"#!/bin/bash",
+		"apt-get update -y; apt-get install -y curl",
+		"wget -qO- https://get.docker.com | sh")
+	require.NoError(t, err)
+	require.Equal(t, `
+#cloud-config
+
+runcmd:
+- apt-get update -y
+- apt-get install -y curl
+- wget -qO- https://get.docker.com | sh
+
+`, cloudInit)
+}
+
 func TestValidate(t *testing.T) {
 	plugin := &plugin{}
 	err := plugin.Validate(types.AnyString(`{"Size":"1gb", "Image": "debian-8-x64"}`))
@@ -63,7 +80,7 @@ func TestDestroyFails(t *testing.T) {
 	id := instance.ID("foo")
 	err := plugin.Destroy(id)
 
-	require.EqualError(t, err, "strconv.Atoi: parsing \"foo\": invalid syntax")
+	require.EqualError(t, err, "strconv.ParseInt: parsing \"foo\": invalid syntax")
 
 	id = instance.ID("12345")
 	err = plugin.Destroy(id)

--- a/plugin/instance/types/types.go
+++ b/plugin/instance/types/types.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"github.com/digitalocean/godo"
 	"github.com/docker/infrakit/pkg/spi/instance"
 	"github.com/docker/infrakit/pkg/types"
 	"github.com/pkg/errors"
@@ -21,13 +22,16 @@ const (
 
 // Properties is the configuration schema for the plugin, provided in instance.Spec.Properties
 type Properties struct {
-	NamePrefix        string
-	Image             string
-	Size              string
-	Backups           bool
-	IPv6              bool `json:"ipv6"`
-	PrivateNetworking bool `json:"private_networking"`
-	Tags              []string
+	godo.DropletCreateRequest
+
+	NamePrefix  string
+	SSHKeyNames []string
+	// Image             string
+	// Size              string
+	// Backups           bool
+	// IPv6              bool `json:"ipv6"`
+	// PrivateNetworking bool `json:"private_networking"`
+	// Tags              []string
 }
 
 // ParseProperties parses instance Properties from a json description.

--- a/plugin/instance/types/types_test.go
+++ b/plugin/instance/types/types_test.go
@@ -3,6 +3,7 @@ package types
 import (
 	"testing"
 
+	"github.com/digitalocean/godo"
 	"github.com/docker/infrakit/pkg/spi/instance"
 	"github.com/docker/infrakit/pkg/types"
 	"github.com/stretchr/testify/assert"
@@ -13,7 +14,7 @@ func TestParseProperties(t *testing.T) {
   "NamePrefix": "foo",
   "Region": "nyc3",
   "Size": "512mb",
-  "Image": "ubuntu-14-04-x64",
+  "Image": { "Slug" : "ubuntu-14-04-x64"},
   "Backups": false,
   "Ipv6": true,
   "Private_networking": null,
@@ -23,13 +24,18 @@ func TestParseProperties(t *testing.T) {
 	p, err := ParseProperties(properties)
 	assert.NoError(t, err)
 	assert.Equal(t, p, Properties{
-		NamePrefix:        "foo",
-		Size:              "512mb",
-		Image:             "ubuntu-14-04-x64",
-		Backups:           false,
-		IPv6:              true,
-		PrivateNetworking: false,
-		Tags:              []string{"foo"},
+		DropletCreateRequest: godo.DropletCreateRequest{
+			Region: "nyc3",
+			Size:   "512mb",
+			Image: godo.DropletCreateImage{
+				Slug: "ubuntu-14-04-x64",
+			},
+			Backups:           false,
+			IPv6:              true,
+			PrivateNetworking: false,
+			Tags:              []string{"foo"},
+		},
+		NamePrefix: "foo",
 	})
 }
 


### PR DESCRIPTION
This PR has a few fixes that are required for proper working of the instance plugin for DO:

  + Add support for [UserData / CloudInit](https://www.digitalocean.com/company/blog/automating-application-deployments-with-user-data/).  This is required for non-linuxkit setup of Docker swarm
  + Add namespace / scoping by labels for the plugin so that droplets created in the same account by users other than infrakit itself will not be included in the listing / DescribeInstances
  + Make the use of plugin's `Properties` more idiomatic ==> specifically, there's it's better to exploit Go's ability to embed structs so that there's no duplication and copying of struct fields.  This way configurations retain high fidelity and when DO releases new versions of SDK, a trivial update of vendor version is all it takes to update the plugin.
  + As a result of above, it's now possible to support multiple SSH keys and specify DO region without restarting the plugin.  Previously these are set as plugin flags.  In general, it's more idiomatic (the 'infrakit way') to rely as little on plugin flags as possible.

I will submit another PR that updates the documentation and adds new Infrakit playbooks for starting the plugin and provisioning droplets.

Signed-off-by: David Chung david.dchung@docker.com 